### PR TITLE
Add option to download as parquet

### DIFF
--- a/shiny_app/Modules/data_download_mod.R
+++ b/shiny_app/Modules/data_download_mod.R
@@ -27,6 +27,9 @@ downloadDataButtonsUI <- function(id) {
                         icon = NULL),
     shiny::downloadLink(ns("downloadJSON"), 
                         label = "as JSON", 
+                        icon = NULL),
+    shiny::downloadLink(ns("downloadParquet"), 
+                        label = "as Parquet", 
                         icon = NULL)
   )
 }
@@ -73,6 +76,14 @@ downloadDataButtonsServer <- function(id, data, selectedColumns = NULL) {
         jsonlite::write_json(as.list(getData()), file)
       }
       
+    )
+
+    # Download as parquet
+    output$downloadParquet <- downloadHandler(
+      filename = paste0("scotpho_data_extract_", Sys.Date(), ".parquet"),
+      content = function(file) {
+        nanoparquet::write_parquet(as.list(getData()), file)
+      }
     )
     
   })

--- a/shiny_app/Modules/data_download_mod.R
+++ b/shiny_app/Modules/data_download_mod.R
@@ -82,7 +82,7 @@ downloadDataButtonsServer <- function(id, data, selectedColumns = NULL) {
     output$downloadParquet <- downloadHandler(
       filename = paste0("scotpho_data_extract_", Sys.Date(), ".parquet"),
       content = function(file) {
-        nanoparquet::write_parquet(as.list(getData()), file)
+        nanoparquet::write_parquet(getData(), file)
       }
     )
     


### PR DESCRIPTION
I've used [`{nanoparquet}`](https://nanoparquet.r-lib.org/reference/write_parquet.html) as it's apparently lightweight, although I'd usually use `{arrow}`.

We've been using parquet as they are very fast to read and write (specifically using the PHS R infrastructure). They're also platform-independent, so are a great alternative to `rds`.